### PR TITLE
Feature/support-more-visio-files

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -2,9 +2,12 @@ steps:
   build-feature:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      repo: ${CI_REPO}
-      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
-    secrets: [docker_username, docker_password]
+      repo: '${CI_REPO_OWNER%%io}/${CI_REPO_NAME}'
+      tags: 'feature-${CI_COMMIT_BRANCH##feature/}'
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  branch: feature/*
-  event: push
+  - event: push
+    branch: [feature/*]

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -2,9 +2,12 @@ steps:
   build-latest:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      repo: ${CI_REPO}
+      repo: '${CI_REPO_OWNER%%io}/${CI_REPO_NAME}'
       tags: latest
-    secrets: [docker_username, docker_password]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  branch: development
-  event: push
+  - event: push
+    branch: [development]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,10 +1,13 @@
 steps:
   build-and-release:
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
     settings:
-      repo: ${CI_REPO}
-      tags: ${CI_COMMIT_TAG##v} # strips v from the tag
+      repo: '${CI_REPO_OWNER%%io}/${CI_REPO_NAME}'
+      tags: '${CI_COMMIT_TAG##v}'
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  event: tag
-  tag: v*
+  - event: tag
+    ref: refs/tags/v*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-python-template:2.0.0-beta.2
+FROM semtech/mu-python-template:2.0.0-beta.3
 LABEL maintainer="info@redpencil.io"
 
 RUN apt-get update && \

--- a/bbo.py
+++ b/bbo.py
@@ -38,7 +38,7 @@ def generate_bbo_flow(_, source_task_id, target_task_id, tasks):
     return flow_uri, flow
 
 
-def generate_bbo_triples(physical_visio_file_path):
+def generate_bbo_triples(physical_visio_file_path, virtual_visio_file_uri):
     triples_per_subject = []
 
     # PROCESS
@@ -50,6 +50,7 @@ def generate_bbo_triples(physical_visio_file_path):
         f"<{process_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowElementsContainer> .",
         f"<{process_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#CallableElement> .",
         f"<{process_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#RootElement> .",
+        f"<{process_uri}> <http://www.w3.org/ns/prov#wasDerivedFrom> <{virtual_visio_file_uri}> .",
     ]
 
     triples_per_subject.append(process)
@@ -68,4 +69,4 @@ def generate_bbo_triples(physical_visio_file_path):
         )
         triples_per_subject.append(triples)
 
-    print(triples_per_subject)
+    return triples_per_subject

--- a/bbo.py
+++ b/bbo.py
@@ -1,0 +1,71 @@
+import re
+from helpers import generate_uuid
+from visio import extract_visio_tasks_flows
+
+
+BASE_URI = "http://data.lblod.info/"
+
+
+def generate_bbo_task(_, name):
+    task_uri = BASE_URI + generate_uuid()
+
+    name = re.sub(r"\s+", " ", name)
+
+    task = [
+        f"<{task_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#Task> .",
+        f"<{task_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#Activity> .",
+        f"<{task_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowNode> .",
+        f"<{task_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowElement> .",
+        f'<{task_uri}> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#name> "{name}" .',
+    ]
+
+    return task_uri, task
+
+
+def generate_bbo_flow(_, source_task_id, target_task_id, tasks):
+    flow_uri = BASE_URI + generate_uuid()
+
+    source_task_uri = tasks[source_task_id][0]
+    target_task_uri = tasks[target_task_id][0]
+
+    flow = [
+        f"<{flow_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#SequenceFlow> .",
+        f"<{flow_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowElement> .",
+        f"<{flow_uri}> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#has_sourceRef> <{source_task_uri}> .",
+        f"<{flow_uri}> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#has_targetRef> <{target_task_uri}> .",
+    ]
+
+    return flow_uri, flow
+
+
+def generate_bbo_triples(physical_visio_file_path):
+    triples_per_subject = []
+
+    # PROCESS
+
+    process_uri = BASE_URI + generate_uuid()
+
+    process = [
+        f"<{process_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#Process> .",
+        f"<{process_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowElementsContainer> .",
+        f"<{process_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#CallableElement> .",
+        f"<{process_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#RootElement> .",
+    ]
+
+    triples_per_subject.append(process)
+
+    # TASKS & FLOWS
+
+    tasks, flows = extract_visio_tasks_flows(
+        physical_visio_file_path,
+        generate_task_fn=generate_bbo_task,
+        generate_flow_fn=generate_bbo_flow,
+    )
+
+    for subject, triples in list(tasks.values()) + list(flows.values()):
+        triples.append(
+            f"<{subject}> <https://www.teamingai-project.eu/belongsToProcess> <{process_uri}> ."
+        )
+        triples_per_subject.append(triples)
+
+    print(triples_per_subject)

--- a/bbo.py
+++ b/bbo.py
@@ -6,23 +6,23 @@ from visio import extract_visio_tasks_flows
 BASE_URI = "http://data.lblod.info/"
 
 
-def generate_bbo_task(_, name):
+def generate_bbo_task(_, label):
     task_uri = BASE_URI + generate_uuid()
 
-    name = re.sub(r"\s+", " ", name)
+    label = re.sub(r"\s+", " ", label)
 
     task = [
         f"<{task_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#Task> .",
         f"<{task_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#Activity> .",
         f"<{task_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowNode> .",
         f"<{task_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowElement> .",
-        f'<{task_uri}> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#name> "{name}" .',
+        f'<{task_uri}> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#name> "{label}" .',
     ]
 
     return task_uri, task
 
 
-def generate_bbo_flow(_, source_task_id, target_task_id, tasks):
+def generate_bbo_flow(_, label, source_task_id, target_task_id, tasks):
     flow_uri = BASE_URI + generate_uuid()
 
     source_task_uri = tasks[source_task_id][0]
@@ -33,6 +33,7 @@ def generate_bbo_flow(_, source_task_id, target_task_id, tasks):
         f"<{flow_uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowElement> .",
         f"<{flow_uri}> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#has_sourceRef> <{source_task_uri}> .",
         f"<{flow_uri}> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#has_targetRef> <{target_task_uri}> .",
+        f'<{flow_uri}> <https://www.irit.fr/recherches/MELODI/ontologies/BBO#name> "{label}" .',
     ]
 
     return flow_uri, flow

--- a/bpmn.py
+++ b/bpmn.py
@@ -7,14 +7,14 @@ from bpmn_tools.layout import graphviz
 from bpmn_tools import util
 
 
-def generate_bpmn_task(id, name):
-    return Task(name, id=f"task_{id}")
+def generate_bpmn_task(id, label):
+    return Task(label, id=f"task_{id}")
 
 
-def generate_bpmn_flow(id, source_task_id, target_task_id, tasks):
+def generate_bpmn_flow(id, label, source_task_id, target_task_id, tasks):
     source_task = tasks[source_task_id]
     target_task = tasks[target_task_id]
-    return Flow(source_task, target_task, id=f"flow_{id}")  # TODO: set flow name
+    return Flow(source_task, target_task, label, id=f"flow_{id}")
 
 
 def generate_raw_bpmn(physical_visio_file_path):

--- a/bpmn.py
+++ b/bpmn.py
@@ -34,8 +34,8 @@ def generate_raw_bpmn(physical_visio_file_path):
 
     # COLLABORATION
 
-    participant = Participant(process=process)  # TODO: fetch from Visio
-    collaboration = Collaboration()  # TODO: fetch from Visio
+    participant = Participant(process=process)
+    collaboration = Collaboration()
     collaboration.append(participant)
 
     # DIAGRAM

--- a/bpmn.py
+++ b/bpmn.py
@@ -1,0 +1,56 @@
+from visio import extract_visio_tasks_flows
+from bpmn_tools.flow import Task, Flow, Process
+from bpmn_tools.notation import Definitions
+from bpmn_tools.diagrams import Plane, Diagram
+from bpmn_tools.collaboration import Collaboration, Participant
+from bpmn_tools.layout import graphviz
+from bpmn_tools import util
+
+
+def generate_bpmn_task(id, name):
+    return Task(name, id=f"task_{id}")
+
+
+def generate_bpmn_flow(id, source_task_id, target_task_id, tasks):
+    source_task = tasks[source_task_id]
+    target_task = tasks[target_task_id]
+    return Flow(source_task, target_task, id=f"flow_{id}")  # TODO: set flow name
+
+
+def generate_raw_bpmn(physical_visio_file_path):
+    # TASKS & FLOWS
+
+    tasks, flows = extract_visio_tasks_flows(
+        physical_visio_file_path,
+        generate_task_fn=generate_bpmn_task,
+        generate_flow_fn=generate_bpmn_flow,
+    )
+
+    # PROCESS
+
+    process = Process()
+    process.extend(tasks.values())
+    process.extend(flows.values())
+
+    # COLLABORATION
+
+    participant = Participant(process=process)  # TODO: fetch from Visio
+    collaboration = Collaboration()  # TODO: fetch from Visio
+    collaboration.append(participant)
+
+    # DIAGRAM
+
+    plane = Plane(element=collaboration)
+    diagram = Diagram(plane=plane)
+
+    # DEFINITIONS
+
+    definitions = Definitions()
+    definitions.append(process)
+    definitions.append(collaboration)
+    definitions.append(diagram)
+
+    # BPMN
+
+    graphviz.layout(definitions)
+    return util.model2xml(definitions)

--- a/sparql_queries.py
+++ b/sparql_queries.py
@@ -1,10 +1,4 @@
-from datetime import datetime, timezone
-from escape_helpers import (
-    sparql_escape_uri,
-    sparql_escape_string,
-    sparql_escape_int,
-    sparql_escape_datetime,
-)
+from escape_helpers import sparql_escape_string
 
 
 def generate_file_uri_select_query(virtual_file_uuid):
@@ -21,51 +15,5 @@ def generate_file_uri_select_query(virtual_file_uuid):
         dbpedia:fileExtension ?fileExtension .
 
       ?physicalFileUri nie:dataSource ?virtualFileUri .
-    }}
-    """
-
-
-def generate_bpmn_file_insert_query(
-    virtual_file_uuid,
-    virtual_file_name,
-    virtual_file_uri,
-    physical_file_uuid,
-    physical_file_name,
-    physical_file_uri,
-    file_size,
-    visio_file_uri,
-):
-    file_format = "text/xml; charset=utf-8"
-    file_extension = "bpmn"
-    now = datetime.now(timezone.utc)
-
-    return f"""
-    PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-    PREFIX dbpedia: <http://dbpedia.org/ontology/>
-    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-    PREFIX dc: <http://purl.org/dc/terms/>
-    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
-
-    INSERT DATA {{
-      {sparql_escape_uri(virtual_file_uri)} a nfo:FileDataObject ;
-          nfo:fileName {sparql_escape_string(virtual_file_name)} ;
-          mu:uuid {sparql_escape_string(virtual_file_uuid)} ;
-          dc:format {sparql_escape_string(file_format)} ;
-          nfo:fileSize {sparql_escape_int(file_size)} ;
-          dbpedia:fileExtension {sparql_escape_string(file_extension)} ;
-          dc:created {sparql_escape_datetime(now)} ;
-          dc:modified {sparql_escape_datetime(now)} ;
-          prov:wasDerivedFrom {sparql_escape_uri(visio_file_uri)} .
-
-      {sparql_escape_uri(physical_file_uri)} a nfo:FileDataObject ;
-          nie:dataSource {sparql_escape_uri(virtual_file_uri)} ;
-          nfo:fileName {sparql_escape_string(physical_file_name)} ;
-          mu:uuid {sparql_escape_string(physical_file_uuid)} ;
-          dc:format {sparql_escape_string(file_format)} ;
-          nfo:fileSize {sparql_escape_int(file_size)} ;
-          dbpedia:fileExtension {sparql_escape_string(file_extension)} ;
-          dc:created {sparql_escape_datetime(now)} ;
-          dc:modified {sparql_escape_datetime(now)} .
     }}
     """

--- a/sparql_queries.py
+++ b/sparql_queries.py
@@ -1,6 +1,14 @@
 from escape_helpers import sparql_escape_string
 
 
+def generate_triples_insert_query(triples):
+    triples = "\n".join(triples)
+    return f"""
+    INSERT DATA {{
+      {triples}
+    }}"""
+
+
 def generate_file_uri_select_query(virtual_file_uuid):
     return f"""
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

--- a/visio.py
+++ b/visio.py
@@ -1,62 +1,70 @@
 from vsdx import VisioFile
+import os
+import shutil
 
 
 def extract_visio_tasks_flows(
     physical_visio_file_path, generate_task_fn, generate_flow_fn
 ):
-    # PAGES
+    try:
+        # PAGES
 
-    visio = VisioFile(physical_visio_file_path)
-    page = visio.get_page(0)  # TODO: loop over pages
+        visio = VisioFile(physical_visio_file_path)
+        page = visio.get_page(0)  # TODO: loop over pages
 
-    # TASKS
+        # TASKS
 
-    tasks = {}
+        tasks = {}
 
-    for shape in page.child_shapes:  # TODO: also consider deeper nested shapes
-        # 'Shape' shapes are 'help' elements in Visio --> of no use in BPMN
-        if shape.shape_type == "Shape":
-            continue
+        for shape in page.child_shapes:  # TODO: also consider deeper nested shapes
+            # 'Shape' shapes are 'help' elements in Visio --> of no use in BPMN
+            if shape.shape_type == "Shape":
+                continue
 
-        label = shape.text.strip() if shape.text is not None else ""
-        tasks[shape.ID] = generate_task_fn(shape.ID, label)
+            label = shape.text.strip() if shape.text is not None else ""
+            tasks[shape.ID] = generate_task_fn(shape.ID, label)
 
-    # FLOWS
+        # FLOWS
 
-    flows_temp = {}
-    flows = {}
+        flows_temp = {}
+        flows = {}
 
-    for connector in page.connects:
-        task_id = connector.xml.attrib.get("ToSheet")
+        for connector in page.connects:
+            task_id = connector.xml.attrib.get("ToSheet")
 
-        # Some connectors are 'help' elements in Visio --> of no use in BPMN
-        if task_id not in tasks:
-            continue
+            # Some connectors are 'help' elements in Visio --> of no use in BPMN
+            if task_id not in tasks:
+                continue
 
-        flow_id = connector.xml.attrib.get("FromSheet")
-        flow_type = connector.xml.attrib.get("FromCell")
+            flow_id = connector.xml.attrib.get("FromSheet")
+            flow_type = connector.xml.attrib.get("FromCell")
 
-        if flow_id not in flows:
-            flows_temp[flow_id] = {}
+            if flow_id not in flows:
+                flows_temp[flow_id] = {}
 
-        if flow_type == "BeginX":
-            flows_temp[flow_id]["source_task_id"] = task_id
-        elif flow_type == "EndX":
-            flows_temp[flow_id]["target_task_id"] = task_id
+            if flow_type == "BeginX":
+                flows_temp[flow_id]["source_task_id"] = task_id
+            elif flow_type == "EndX":
+                flows_temp[flow_id]["target_task_id"] = task_id
 
-        # Create flow object when both source and target are known
-        if (
-            "source_task_id" in flows_temp[flow_id]
-            and "target_task_id" in flows_temp[flow_id]
-        ):
-            source_task_id = flows_temp[flow_id]["source_task_id"]
-            target_task_id = flows_temp[flow_id]["target_task_id"]
+            # Create flow object when both source and target are known
+            if (
+                "source_task_id" in flows_temp[flow_id]
+                and "target_task_id" in flows_temp[flow_id]
+            ):
+                source_task_id = flows_temp[flow_id]["source_task_id"]
+                target_task_id = flows_temp[flow_id]["target_task_id"]
 
-            flow_shape = page.find_shape_by_id(flow_id)
-            label = flow_shape.text.strip() if flow_shape.text is not None else ""
+                flow_shape = page.find_shape_by_id(flow_id)
+                label = flow_shape.text.strip() if flow_shape.text is not None else ""
 
-            flows[flow_id] = generate_flow_fn(
-                flow_id, label, source_task_id, target_task_id, tasks
-            )
+                flows[flow_id] = generate_flow_fn(
+                    flow_id, label, source_task_id, target_task_id, tasks
+                )
 
-    return tasks, flows
+        return tasks, flows
+
+    finally:
+        helper_folder = os.path.splitext(physical_visio_file_path)[0]
+        if os.path.isdir(helper_folder):
+            shutil.rmtree(helper_folder)

--- a/visio.py
+++ b/visio.py
@@ -15,8 +15,11 @@ def extract_visio_tasks_flows(
         # TASKS
 
         tasks = {}
+        shapes_by_id = {}
 
         for shape in page.child_shapes:  # TODO: also consider deeper nested shapes
+            shapes_by_id[shape.ID] = shape
+            
             # 'Shape' shapes are 'help' elements in Visio --> of no use in BPMN
             if shape.shape_type == "Shape":
                 continue
@@ -55,7 +58,7 @@ def extract_visio_tasks_flows(
                 source_task_id = flows_temp[flow_id]["source_task_id"]
                 target_task_id = flows_temp[flow_id]["target_task_id"]
 
-                flow_shape = page.find_shape_by_id(flow_id)
+                flow_shape = shapes_by_id[flow_id]
                 label = flow_shape.text.strip() if flow_shape.text is not None else ""
 
                 flows[flow_id] = generate_flow_fn(

--- a/visio.py
+++ b/visio.py
@@ -18,7 +18,8 @@ def extract_visio_tasks_flows(
         if shape.shape_type == "Shape":
             continue
 
-        tasks[shape.ID] = generate_task_fn(shape.ID, shape.text.strip())
+        label = shape.text.strip() if shape.text is not None else ""
+        tasks[shape.ID] = generate_task_fn(shape.ID, label)
 
     # FLOWS
 
@@ -51,8 +52,11 @@ def extract_visio_tasks_flows(
             source_task_id = flows_temp[flow_id]["source_task_id"]
             target_task_id = flows_temp[flow_id]["target_task_id"]
 
+            flow_shape = page.find_shape_by_id(flow_id)
+            label = flow_shape.text.strip() if flow_shape.text is not None else ""
+
             flows[flow_id] = generate_flow_fn(
-                flow_id, source_task_id, target_task_id, tasks
+                flow_id, label, source_task_id, target_task_id, tasks
             )
 
     return tasks, flows

--- a/visio.py
+++ b/visio.py
@@ -39,7 +39,7 @@ def extract_visio_tasks_flows(
             flow_id = connector.xml.attrib.get("FromSheet")
             flow_type = connector.xml.attrib.get("FromCell")
 
-            if flow_id not in flows:
+            if flow_id not in flows_temp:
                 flows_temp[flow_id] = {}
 
             if flow_type == "BeginX":

--- a/visio.py
+++ b/visio.py
@@ -22,6 +22,7 @@ def extract_visio_tasks_flows(
 
     # FLOWS
 
+    flows_temp = {}
     flows = {}
 
     for connector in page.connects:
@@ -35,17 +36,20 @@ def extract_visio_tasks_flows(
         flow_type = connector.xml.attrib.get("FromCell")
 
         if flow_id not in flows:
-            flows[flow_id] = {}
+            flows_temp[flow_id] = {}
 
         if flow_type == "BeginX":
-            flows[flow_id]["source_task_id"] = task_id
+            flows_temp[flow_id]["source_task_id"] = task_id
         elif flow_type == "EndX":
-            flows[flow_id]["target_task_id"] = task_id
+            flows_temp[flow_id]["target_task_id"] = task_id
 
         # Create flow object when both source and target are known
-        if "source_task_id" in flows[flow_id] and "target_task_id" in flows[flow_id]:
-            source_task_id = flows[flow_id]["source_task_id"]
-            target_task_id = flows[flow_id]["target_task_id"]
+        if (
+            "source_task_id" in flows_temp[flow_id]
+            and "target_task_id" in flows_temp[flow_id]
+        ):
+            source_task_id = flows_temp[flow_id]["source_task_id"]
+            target_task_id = flows_temp[flow_id]["target_task_id"]
 
             flows[flow_id] = generate_flow_fn(
                 flow_id, source_task_id, target_task_id, tasks

--- a/visio.py
+++ b/visio.py
@@ -1,0 +1,54 @@
+from vsdx import VisioFile
+
+
+def extract_visio_tasks_flows(
+    physical_visio_file_path, generate_task_fn, generate_flow_fn
+):
+    # PAGES
+
+    visio = VisioFile(physical_visio_file_path)
+    page = visio.get_page(0)  # TODO: loop over pages
+
+    # TASKS
+
+    tasks = {}
+
+    for shape in page.child_shapes:  # TODO: also consider deeper nested shapes
+        # 'Shape' shapes are 'help' elements in Visio --> of no use in BPMN
+        if shape.shape_type == "Shape":
+            continue
+
+        tasks[shape.ID] = generate_task_fn(shape.ID, shape.text.strip())
+
+    # FLOWS
+
+    flows = {}
+
+    for connector in page.connects:
+        task_id = connector.xml.attrib.get("ToSheet")
+
+        # Some connectors are 'help' elements in Visio --> of no use in BPMN
+        if task_id not in tasks:
+            continue
+
+        flow_id = connector.xml.attrib.get("FromSheet")
+        flow_type = connector.xml.attrib.get("FromCell")
+
+        if flow_id not in flows:
+            flows[flow_id] = {}
+
+        if flow_type == "BeginX":
+            flows[flow_id]["source_task_id"] = task_id
+        elif flow_type == "EndX":
+            flows[flow_id]["target_task_id"] = task_id
+
+        # Create flow object when both source and target are known
+        if "source_task_id" in flows[flow_id] and "target_task_id" in flows[flow_id]:
+            source_task_id = flows[flow_id]["source_task_id"]
+            target_task_id = flows[flow_id]["target_task_id"]
+
+            flows[flow_id] = generate_flow_fn(
+                flow_id, source_task_id, target_task_id, tasks
+            )
+
+    return tasks, flows

--- a/web.py
+++ b/web.py
@@ -1,16 +1,10 @@
+from bpmn import generate_raw_bpmn
 from flask import request, jsonify, send_file, Response
 from helpers import error, query, update, generate_uuid
 from sparql_queries import (
     generate_file_uri_select_query,
     generate_bpmn_file_insert_query,
 )
-from vsdx import VisioFile
-from bpmn_tools.flow import Task, Flow, Process
-from bpmn_tools.notation import Definitions
-from bpmn_tools.diagrams import Plane, Diagram
-from bpmn_tools.collaboration import Collaboration, Participant
-from bpmn_tools.layout import graphviz
-from bpmn_tools import util
 from pathlib import Path
 import os
 import subprocess
@@ -165,84 +159,3 @@ def convert_visio_to_bpmn():
             "bpmn-file-id": virtual_bpmn_file_uuid,
         }
     ), 201
-
-
-def generate_raw_bpmn(physical_visio_file_path):
-    # PAGES
-
-    visio = VisioFile(physical_visio_file_path)
-    page = visio.get_page(0)  # TODO: loop over pages
-
-    # TASKS
-
-    tasks = {}
-
-    for shape in page.child_shapes:  # TODO: also consider deeper nested shapes
-        # 'Shape' shapes are 'help' elements in Visio --> of no use in BPMN
-        if shape.shape_type == "Shape":
-            continue
-
-        tasks[shape.ID] = Task(shape.text.strip(), id=f"task_{shape.ID}")
-
-    # FLOWS
-
-    flows = {}
-
-    for connector in page.connects:
-        task_id = connector.xml.attrib.get("ToSheet")
-
-        # Some connectors are 'help' elements in Visio --> of no use in BPMN
-        if task_id not in tasks:
-            continue
-
-        flow_id = connector.xml.attrib.get("FromSheet")
-        flow_type = connector.xml.attrib.get("FromCell")
-
-        if flow_id not in flows:
-            flows[flow_id] = {}
-
-        if flow_type == "BeginX":
-            flows[flow_id]["source_task_id"] = task_id
-        elif flow_type == "EndX":
-            flows[flow_id]["target_task_id"] = task_id
-
-        # Create flow object when both source and target are known
-        if "source_task_id" in flows[flow_id] and "target_task_id" in flows[flow_id]:
-            source_task_id = flows[flow_id]["source_task_id"]
-            target_task_id = flows[flow_id]["target_task_id"]
-
-            source_task = tasks[source_task_id]
-            target_task = tasks[target_task_id]
-
-            flows[flow_id] = Flow(
-                source_task, target_task, id=f"flow_{flow_id}"
-            )  # TODO: set flow name
-
-    # PROCESS
-
-    process = Process()
-    process.extend(tasks.values())
-    process.extend(flows.values())
-
-    # COLLABORATION
-
-    participant = Participant(process=process)  # TODO: fetch from Visio
-    collaboration = Collaboration()  # TODO: fetch from Visio
-    collaboration.append(participant)
-
-    # DIAGRAM
-
-    plane = Plane(element=collaboration)
-    diagram = Diagram(plane=plane)
-
-    # DEFINITIONS
-
-    definitions = Definitions()
-    definitions.append(process)
-    definitions.append(collaboration)
-    definitions.append(diagram)
-
-    # BPMN
-
-    graphviz.layout(definitions)
-    return util.model2xml(definitions)

--- a/web.py
+++ b/web.py
@@ -118,9 +118,11 @@ def convert_visio_to_bpmn():
         return error("Could not find file in path.", 500)
 
     try:
-        generate_bbo_triples(physical_visio_file_path)
+        triples_per_subject = generate_bbo_triples(
+            physical_visio_file_path, virtual_visio_file_uri
+        )
     except Exception as e:
         print(e)
         return error("Something went wrong during process steps extraction.", 500)
 
-    return "Process steps extracted."
+    return triples_per_subject

--- a/web.py
+++ b/web.py
@@ -121,8 +121,35 @@ def convert_visio_to_bpmn():
         triples_per_subject = generate_bbo_triples(
             physical_visio_file_path, virtual_visio_file_uri
         )
+        insert_triple_chunks(triples_per_subject)
     except Exception as e:
         print(e)
         return error("Something went wrong during process steps extraction.", 500)
 
     return triples_per_subject
+
+
+def insert_triple_chunks(triple_chunks, max_triples_per_insert=100):
+    index = 0
+    triples_to_insert = []
+
+    while index < len(triple_chunks):
+        if (
+            len(triples_to_insert) == 0
+            or len(triples_to_insert) + len(triple_chunks[index])
+            <= max_triples_per_insert
+        ):
+            triples_to_insert.extend(triple_chunks[index])
+
+        index += 1
+
+        if (
+            index >= len(triple_chunks)
+            or len(triples_to_insert) + len(triple_chunks[index])
+            >= max_triples_per_insert
+        ):
+            print(triples_to_insert)
+            print("########################")
+            # triples_insert_query = generate_triples_insert_query(triples_to_insert)
+            # update(triples_insert_query)
+            triples_to_insert = []

--- a/web.py
+++ b/web.py
@@ -1,11 +1,8 @@
+from bbo import generate_bbo_triples
 from bpmn import generate_raw_bpmn
-from flask import request, jsonify, send_file, Response
-from helpers import error, query, update, generate_uuid
-from sparql_queries import (
-    generate_file_uri_select_query,
-    generate_bpmn_file_insert_query,
-)
-from pathlib import Path
+from flask import request, send_file, Response
+from helpers import error, query
+from sparql_queries import generate_file_uri_select_query
 import os
 import subprocess
 import tempfile
@@ -106,7 +103,6 @@ def convert_visio_to_bpmn():
     if not visio_file_uri_bindings:
         return error("Not Found", 404)
 
-    virtual_visio_file_name = visio_file_uri_bindings[0]["virtualFileName"]["value"]
     virtual_visio_file_uri = visio_file_uri_bindings[0]["virtualFileUri"]["value"]
 
     physical_visio_file_uri = visio_file_uri_bindings[0]["physicalFileUri"]["value"]
@@ -122,40 +118,9 @@ def convert_visio_to_bpmn():
         return error("Could not find file in path.", 500)
 
     try:
-        bpmn_raw = generate_raw_bpmn(physical_visio_file_path)
+        generate_bbo_triples(physical_visio_file_path)
     except Exception as e:
         print(e)
-        return error("Something went wrong during conversion", 500)
+        return error("Something went wrong during process steps extraction.", 500)
 
-    virtual_bpmn_file_uuid = generate_uuid()
-    virtual_bpmn_file_name = f"{os.path.splitext(virtual_visio_file_name)[0]}.bpmn"
-    virtual_bpmn_file_uri = f"{FILE_URI_PREFIX}/{virtual_bpmn_file_uuid}"
-
-    physical_bpmn_file_uuid = generate_uuid()
-    physical_bpmn_file_name = f"{physical_bpmn_file_uuid}.bpmn"
-    physical_bpmn_file_uri = f"share://{physical_bpmn_file_name}"
-    physical_bpmn_file_path = physical_bpmn_file_uri.replace(
-        "share://", STORAGE_FOLDER_PATH
-    )
-
-    Path(physical_bpmn_file_path).write_text(bpmn_raw)
-
-    bpmn_file_insert_query = generate_bpmn_file_insert_query(
-        virtual_bpmn_file_uuid,
-        virtual_bpmn_file_name,
-        virtual_bpmn_file_uri,
-        physical_bpmn_file_uuid,
-        physical_bpmn_file_name,
-        physical_bpmn_file_uri,
-        os.path.getsize(physical_bpmn_file_path),
-        virtual_visio_file_uri,
-    )
-    update(bpmn_file_insert_query)
-
-    return jsonify(
-        {
-            "message": "Visio file successfully converted to BPMN",
-            "visio-file-id": virtual_visio_file_uuid,
-            "bpmn-file-id": virtual_bpmn_file_uuid,
-        }
-    ), 201
+    return "Process steps extracted."

--- a/web.py
+++ b/web.py
@@ -2,7 +2,7 @@ from bbo import generate_bbo_triples
 from bpmn import generate_raw_bpmn
 from flask import request, send_file, Response
 from helpers import error, query
-from sparql_queries import generate_file_uri_select_query
+from sparql_queries import generate_file_uri_select_query, generate_triples_insert_query
 import os
 import subprocess
 import tempfile
@@ -126,7 +126,7 @@ def convert_visio_to_bpmn():
         print(e)
         return error("Something went wrong during process steps extraction.", 500)
 
-    return triples_per_subject
+    return "Process steps extracted."
 
 
 def insert_triple_chunks(triple_chunks, max_triples_per_insert=100):
@@ -148,8 +148,6 @@ def insert_triple_chunks(triple_chunks, max_triples_per_insert=100):
             or len(triples_to_insert) + len(triple_chunks[index])
             >= max_triples_per_insert
         ):
-            print(triples_to_insert)
-            print("########################")
-            # triples_insert_query = generate_triples_insert_query(triples_to_insert)
+            triples_insert_query = generate_triples_insert_query(triples_to_insert)
             # update(triples_insert_query)
             triples_to_insert = []


### PR DESCRIPTION
OPH-628

More types of Visio files can now be parsed by the service, meaning converting to BPMN should now work for more types of Visio files.

The logic is also more generic so it can be used to convert Visio files to BBO triples as well. However, this functionality should still be worked out further, so it isn't active yet.

For easy testing, I already made the changes available on the dev server:
- downloading the following file as BPMN already worked before, so it should still work: https://dev.openproceshuis.lblod.info/processen/67CABCD3435091678276296E
- downloading the following file as BPMN did not work before, but should now work: https://dev.openproceshuis.lblod.info/processen/68650349A80B5AE78DF4F491

⚠️ The results are in no way perfect. Most notably, tasks are scattered throughout the page. However, this shortcoming was already discussed and the decision was made to still move on. It might be a good idea to have some sort of a warning/tooltip on the BPMN download button indicating results are suboptimal. To be discussed.